### PR TITLE
Terraform移行とGitHub OIDC管理の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,10 @@ cdk.out
 
 *.js
 *.d.ts
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+terraform/terraform.tfvars

--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@
     1. ワークスペースとの連携まで
 2. `npm i`
 3. デプロイを実行 `npm run cdk deploy`
+
+## Terraform運用
+
+1. `terraform/terraform.tfvars.example` を `terraform/terraform.tfvars` にコピー
+2. `slack_team_id` と `slack_channel_id` を設定
+3. `terraform -chdir=terraform init`
+4. `terraform -chdir=terraform plan`
+5. 反映が必要なら `terraform -chdir=terraform apply`

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = ">= 5.0.0, < 6.0.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/github_oidc.tf
+++ b/terraform/github_oidc.tf
@@ -1,0 +1,147 @@
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com",
+  ]
+
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
+  ]
+
+  tags = {
+    Project = "sandbox-go-function"
+    Purpose = "GitHub Actions OIDC"
+  }
+}
+
+resource "aws_iam_role" "about_deploy" {
+  name = "about-deploy"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github_actions.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:dsk52/about:ref:refs/heads/main"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Env     = "prod"
+    Project = "about"
+  }
+}
+
+resource "aws_iam_role_policy" "about_deploy" {
+  name = "about-deploy-policy"
+  role = aws_iam_role.about_deploy.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+        ]
+        Resource = "arn:aws:s3:::daisukekonishi.com"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:PutObjectTagging",
+          "s3:PutObject",
+          "s3:GetObjectTagging",
+          "s3:GetObject",
+          "s3:DeleteObject",
+        ]
+        Resource = "arn:aws:s3:::daisukekonishi.com/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "cloudfront:CreateInvalidation"
+        Resource = "arn:aws:cloudfront::178083574992:distribution/E155XX968EDVQB"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role" "sandbox_go_function_github_actions" {
+  name = "sandbox-go-function-github-actions-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github_actions.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = [
+              "repo:dsk52/sandbox-go-function:*",
+              "repo:dsk52/sandbox-go-function:ref:refs/heads/main",
+            ]
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Purpose = "GitHub Actions Deployment"
+    Project = "sandbox-go-function"
+  }
+}
+
+resource "aws_iam_policy" "sandbox_go_function_github_actions_lambda_deploy" {
+  name        = "sandbox-go-function-github-actions-lambda-deploy"
+  description = "Policy for GitHub Actions to deploy Lambda functions using aws-lambda-deploy action"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "lambda:UpdateFunctionConfiguration",
+          "lambda:UpdateFunctionCode",
+          "lambda:PublishVersion",
+          "lambda:GetFunctionConfiguration",
+          "lambda:CreateFunction",
+        ]
+        Resource = "arn:aws:lambda:us-west-2:178083574992:function:sandbox-go-function"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "iam:PassRole"
+        Resource = "arn:aws:iam::178083574992:role/*lambda*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "sandbox_go_function_github_actions_lambda_deploy" {
+  role       = aws_iam_role.sandbox_go_function_github_actions.name
+  policy_arn = aws_iam_policy.sandbox_go_function_github_actions_lambda_deploy.arn
+}

--- a/terraform/github_oidc.tf
+++ b/terraform/github_oidc.tf
@@ -33,7 +33,10 @@ resource "aws_iam_role" "about_deploy" {
             "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
           }
           StringLike = {
-            "token.actions.githubusercontent.com:sub" = "repo:dsk52/about:ref:refs/heads/main"
+            "token.actions.githubusercontent.com:sub" = [
+              "repo:dsk52/about:ref:refs/heads/main",
+              "repo:dsk52/about:ref:refs/heads/master",
+            ]
           }
         }
       }
@@ -101,6 +104,7 @@ resource "aws_iam_role" "sandbox_go_function_github_actions" {
             "token.actions.githubusercontent.com:sub" = [
               "repo:dsk52/sandbox-go-function:*",
               "repo:dsk52/sandbox-go-function:ref:refs/heads/main",
+              "repo:dsk52/sandbox-go-function:ref:refs/heads/master",
             ]
           }
         }

--- a/terraform/imports.md
+++ b/terraform/imports.md
@@ -1,0 +1,27 @@
+# Terraform import commands
+
+## Prerequisites
+
+- Create `terraform/terraform.tfvars` from `terraform/terraform.tfvars.example`.
+- Ensure AWS profile `default` exists (or update `aws_profile` and backend profile).
+- Run `terraform -chdir=terraform init`.
+
+## Imports
+
+```bash
+terraform -chdir=terraform import aws_iam_role.chatbot_role ChatbotStack-ChatbotRole8A87AA1F-Kor5BnZZMXBr
+terraform -chdir=terraform import aws_sns_topic.budget_alerts arn:aws:sns:ap-northeast-1:178083574992:BudgetNotificationStack-BudgetAlertTopicF20DF526-fjln1hT3HCgC
+terraform -chdir=terraform import aws_sns_topic_policy.budget_alerts_publish arn:aws:sns:ap-northeast-1:178083574992:BudgetNotificationStack-BudgetAlertTopicF20DF526-fjln1hT3HCgC
+terraform -chdir=terraform import aws_sns_topic.health_check arn:aws:sns:ap-northeast-1:178083574992:HealthCheckNotificationStack-HealthCheckTopic4D4B188A-DL8RJOyqk6Au
+terraform -chdir=terraform import aws_chatbot_slack_channel_configuration.budget_alerts arn:aws:chatbot::178083574992:chat-configuration/slack-channel/BudgetAlertsChannel
+
+terraform -chdir=terraform import aws_route53_health_check.main_site 9381dafb-34e8-4cc8-b1e2-a73a611347a8
+terraform -chdir=terraform import aws_route53_health_check.blog_site 1f4929bf-12af-4f08-925d-35e5065da238
+terraform -chdir=terraform import aws_route53_health_check.memo_drip 3d32c2c3-7250-4247-992c-9f3b0b673942
+
+terraform -chdir=terraform import aws_cloudwatch_metric_alarm.main_site daisukekonishi.com-health-check
+terraform -chdir=terraform import aws_cloudwatch_metric_alarm.blog_site blog.daisukekonishi.com-health-check
+terraform -chdir=terraform import aws_cloudwatch_metric_alarm.memo_drip memodrip.net-health-check
+
+terraform -chdir=terraform import aws_budgets_budget.monthly_cost 178083574992:MonthlyCostBudget
+```

--- a/terraform/imports.md
+++ b/terraform/imports.md
@@ -25,3 +25,16 @@ terraform -chdir=terraform import aws_cloudwatch_metric_alarm.memo_drip memodrip
 
 terraform -chdir=terraform import aws_budgets_budget.monthly_cost 178083574992:MonthlyCostBudget
 ```
+
+## GitHub OIDC Imports
+
+```bash
+terraform -chdir=terraform import aws_iam_openid_connect_provider.github_actions arn:aws:iam::178083574992:oidc-provider/token.actions.githubusercontent.com
+
+terraform -chdir=terraform import aws_iam_role.about_deploy about-deploy
+terraform -chdir=terraform import aws_iam_role_policy.about_deploy about-deploy:about-deploy-policy
+
+terraform -chdir=terraform import aws_iam_role.sandbox_go_function_github_actions sandbox-go-function-github-actions-role
+terraform -chdir=terraform import aws_iam_policy.sandbox_go_function_github_actions_lambda_deploy arn:aws:iam::178083574992:policy/sandbox-go-function-github-actions-lambda-deploy
+terraform -chdir=terraform import aws_iam_role_policy_attachment.sandbox_go_function_github_actions_lambda_deploy sandbox-go-function-github-actions-role/arn:aws:iam::178083574992:policy/sandbox-go-function-github-actions-lambda-deploy
+```

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,187 @@
+resource "aws_iam_role" "chatbot_role" {
+  name = "ChatbotStack-ChatbotRole8A87AA1F-Kor5BnZZMXBr"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "sts:AssumeRole"
+        Principal = {
+          Service = "chatbot.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+}
+
+resource "aws_iam_role_policy_attachment" "chatbot_read_only" {
+  role       = aws_iam_role.chatbot_role.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "chatbot_cloudwatch_read_only" {
+  role       = aws_iam_role.chatbot_role.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
+}
+
+resource "aws_sns_topic" "budget_alerts" {
+  name         = "BudgetNotificationStack-BudgetAlertTopicF20DF526-fjln1hT3HCgC"
+  display_name = "Budget Alert Notifications"
+}
+
+resource "aws_sns_topic_policy" "budget_alerts_publish" {
+  arn = aws_sns_topic.budget_alerts.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "0"
+        Effect = "Allow"
+        Principal = {
+          Service = "budgets.amazonaws.com"
+        }
+        Action   = "sns:Publish"
+        Resource = aws_sns_topic.budget_alerts.arn
+      }
+    ]
+  })
+}
+
+resource "aws_sns_topic" "health_check" {
+  name = "HealthCheckNotificationStack-HealthCheckTopic4D4B188A-DL8RJOyqk6Au"
+}
+
+resource "aws_chatbot_slack_channel_configuration" "budget_alerts" {
+  configuration_name = "BudgetAlertsChannel"
+  slack_team_id      = var.slack_team_id
+  slack_channel_id   = var.slack_channel_id
+  iam_role_arn        = aws_iam_role.chatbot_role.arn
+
+  sns_topic_arns = [
+    aws_sns_topic.budget_alerts.arn,
+    aws_sns_topic.health_check.arn,
+  ]
+}
+
+resource "aws_budgets_budget" "monthly_cost" {
+  provider    = aws.us_east_1
+  name        = "MonthlyCostBudget"
+  budget_type = "COST"
+  time_unit   = "MONTHLY"
+  limit_amount = "5"
+  limit_unit   = "USD"
+
+  notification {
+    comparison_operator = "GREATER_THAN"
+    notification_type   = "ACTUAL"
+    threshold           = 50
+    threshold_type      = "PERCENTAGE"
+
+    subscriber_sns_topic_arns = [aws_sns_topic.budget_alerts.arn]
+  }
+
+  notification {
+    comparison_operator = "GREATER_THAN"
+    notification_type   = "ACTUAL"
+    threshold           = 80
+    threshold_type      = "PERCENTAGE"
+
+    subscriber_sns_topic_arns = [aws_sns_topic.budget_alerts.arn]
+  }
+}
+
+resource "aws_route53_health_check" "main_site" {
+  type              = "HTTPS"
+  fqdn              = "daisukekonishi.com"
+  port              = 443
+  resource_path     = "/"
+  failure_threshold = 3
+  request_interval  = 30
+  regions           = ["ap-northeast-1", "ap-southeast-1", "us-west-2"]
+
+  tags = {
+    Name = "MainSite"
+  }
+}
+
+resource "aws_route53_health_check" "blog_site" {
+  type              = "HTTPS"
+  fqdn              = "blog.daisukekonishi.com"
+  port              = 443
+  resource_path     = "/"
+  failure_threshold = 3
+  request_interval  = 30
+  regions           = ["ap-northeast-1", "ap-southeast-1", "us-west-2"]
+
+  tags = {
+    Name = "BlogSite"
+  }
+}
+
+resource "aws_route53_health_check" "memo_drip" {
+  type              = "HTTPS"
+  fqdn              = "memodrip.net"
+  port              = 443
+  resource_path     = "/"
+  failure_threshold = 3
+  request_interval  = 30
+  regions           = ["ap-northeast-1", "ap-southeast-1", "us-west-2"]
+
+  tags = {
+    Name = "MemoDrip"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "main_site" {
+  alarm_name          = "daisukekonishi.com-health-check"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 2
+  threshold           = 1
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  statistic           = "Minimum"
+  period              = 60
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.main_site.id
+  }
+
+  alarm_actions = [aws_sns_topic.health_check.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "blog_site" {
+  alarm_name          = "blog.daisukekonishi.com-health-check"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 2
+  threshold           = 1
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  statistic           = "Minimum"
+  period              = 60
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.blog_site.id
+  }
+
+  alarm_actions = [aws_sns_topic.health_check.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "memo_drip" {
+  alarm_name          = "memodrip.net-health-check"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 2
+  threshold           = 1
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  statistic           = "Minimum"
+  period              = 60
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.memo_drip.id
+  }
+
+  alarm_actions = [aws_sns_topic.health_check.arn]
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = var.aws_profile
+}
+
+provider "aws" {
+  alias   = "us_east_1"
+  region  = "us-east-1"
+  profile = var.aws_profile
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,3 @@
+aws_profile    = "default"
+slack_team_id  = "T7TUQS8D6"
+slack_channel_id = "C0601CQ3DL6"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,15 @@
+variable "aws_profile" {
+  type        = string
+  description = "AWS CLI profile name to use for providers and backend."
+  default     = "default"
+}
+
+variable "slack_team_id" {
+  type        = string
+  description = "Slack team/workspace ID for AWS Chatbot."
+}
+
+variable "slack_channel_id" {
+  type        = string
+  description = "Slack channel ID for AWS Chatbot."
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.5.0, < 2.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 6.0"
+    }
+  }
+
+  backend "s3" {
+    bucket  = "dsk52-foundation-vnx3xku"
+    key     = "terraform/aws-foundation-ops/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "default"
+  }
+}


### PR DESCRIPTION
## 概要
- CDKリソースをTerraform管理へ移行（imports/構成追加）
- Terraform運用手順をREADMEに追記
- GitHub OIDC Providerと関連IAM Role/PolicyをTerraform管理へ移行
- GitHub OIDCの許可ブランチにmasterを追加

## 変更点
- terraform/ 配下に構成一式を追加
- imports手順を整理
- READMEにTerraform運用手順を追加

## 注意点
- 既存リソースはimport済みで plan は No changes
- CloudFormationスタックは削除済み（Retainでリソース保持）
