### PR TITLE
[codex] Budget の月次上限を20USDに変更

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -71,7 +71,7 @@ resource "aws_budgets_budget" "monthly_cost" {
   name        = "MonthlyCostBudget"
   budget_type = "COST"
   time_unit   = "MONTHLY"
-  limit_amount = "5"
+  limit_amount = "20"
   limit_unit   = "USD"
 
   notification {


### PR DESCRIPTION
## 概要
AWS Budget の月次コスト上限を 5 USD から 20 USD に引き上げます。

## 変更内容
- `aws_budgets_budget.monthly_cost` の `limit_amount` を `20` に変更

## 背景
- 現在の Budget 上限が低いため、運用上の想定に合わせて閾値を見直します。

## 確認内容
- `terraform -chdir=terraform plan -no-color`
- `aws_budgets_budget.monthly_cost` の `limit_amount` 変更のみが差分であることを確認