### PR TITLE
[codex] memodrip.netのヘルスチェックを削除

### DIFF
--- a/terraform/imports.md
+++ b/terraform/imports.md
@@ -17,11 +17,8 @@ terraform -chdir=terraform import aws_chatbot_slack_channel_configuration.budget
 
 terraform -chdir=terraform import aws_route53_health_check.main_site 9381dafb-34e8-4cc8-b1e2-a73a611347a8
 terraform -chdir=terraform import aws_route53_health_check.blog_site 1f4929bf-12af-4f08-925d-35e5065da238
-terraform -chdir=terraform import aws_route53_health_check.memo_drip 3d32c2c3-7250-4247-992c-9f3b0b673942
-
 terraform -chdir=terraform import aws_cloudwatch_metric_alarm.main_site daisukekonishi.com-health-check
 terraform -chdir=terraform import aws_cloudwatch_metric_alarm.blog_site blog.daisukekonishi.com-health-check
-terraform -chdir=terraform import aws_cloudwatch_metric_alarm.memo_drip memodrip.net-health-check
 
 terraform -chdir=terraform import aws_budgets_budget.monthly_cost 178083574992:MonthlyCostBudget
 ```

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -58,7 +58,7 @@ resource "aws_chatbot_slack_channel_configuration" "budget_alerts" {
   configuration_name = "BudgetAlertsChannel"
   slack_team_id      = var.slack_team_id
   slack_channel_id   = var.slack_channel_id
-  iam_role_arn        = aws_iam_role.chatbot_role.arn
+  iam_role_arn       = aws_iam_role.chatbot_role.arn
 
   sns_topic_arns = [
     aws_sns_topic.budget_alerts.arn,
@@ -67,10 +67,10 @@ resource "aws_chatbot_slack_channel_configuration" "budget_alerts" {
 }
 
 resource "aws_budgets_budget" "monthly_cost" {
-  provider    = aws.us_east_1
-  name        = "MonthlyCostBudget"
-  budget_type = "COST"
-  time_unit   = "MONTHLY"
+  provider     = aws.us_east_1
+  name         = "MonthlyCostBudget"
+  budget_type  = "COST"
+  time_unit    = "MONTHLY"
   limit_amount = "20"
   limit_unit   = "USD"
 
@@ -121,20 +121,6 @@ resource "aws_route53_health_check" "blog_site" {
   }
 }
 
-resource "aws_route53_health_check" "memo_drip" {
-  type              = "HTTPS"
-  fqdn              = "memodrip.net"
-  port              = 443
-  resource_path     = "/"
-  failure_threshold = 3
-  request_interval  = 30
-  regions           = ["ap-northeast-1", "ap-southeast-1", "us-west-2"]
-
-  tags = {
-    Name = "MemoDrip"
-  }
-}
-
 resource "aws_cloudwatch_metric_alarm" "main_site" {
   alarm_name          = "daisukekonishi.com-health-check"
   comparison_operator = "LessThanThreshold"
@@ -164,23 +150,6 @@ resource "aws_cloudwatch_metric_alarm" "blog_site" {
 
   dimensions = {
     HealthCheckId = aws_route53_health_check.blog_site.id
-  }
-
-  alarm_actions = [aws_sns_topic.health_check.arn]
-}
-
-resource "aws_cloudwatch_metric_alarm" "memo_drip" {
-  alarm_name          = "memodrip.net-health-check"
-  comparison_operator = "LessThanThreshold"
-  evaluation_periods  = 2
-  threshold           = 1
-  metric_name         = "HealthCheckStatus"
-  namespace           = "AWS/Route53"
-  statistic           = "Minimum"
-  period              = 60
-
-  dimensions = {
-    HealthCheckId = aws_route53_health_check.memo_drip.id
   }
 
   alarm_actions = [aws_sns_topic.health_check.arn]


### PR DESCRIPTION
## 概要
memodrip.net 向けの Route53 Health Check と CloudWatch Alarm を Terraform 管理対象から削除しました。

## 変更内容
- `aws_route53_health_check.memo_drip` を削除
- `aws_cloudwatch_metric_alarm.memo_drip` を削除
- `terraform/imports.md` から memodrip.net 向け import 手順を削除
- `terraform fmt` による整形差分を反映

## 背景
memodrip.net のヘルスチェックは不要になったため、監視定義と関連ドキュメントを合わせて整理しました。

## 影響
- memodrip.net の外形監視とアラーム通知が削除されます
- 既存の `daisukekonishi.com` と `blog.daisukekonishi.com` の監視には影響しません

## 確認内容
- `terraform -chdir=terraform plan -no-color`
  - `aws_route53_health_check.memo_drip` の削除
  - `aws_cloudwatch_metric_alarm.memo_drip` の削除
  - `Plan: 0 to add, 0 to change, 2 to destroy`
